### PR TITLE
Move to 64bit hash and custom hash functions

### DIFF
--- a/hashmap.go
+++ b/hashmap.go
@@ -32,8 +32,7 @@ type HashMap struct {
 }
 
 const (
-	// lobSize        = 3
-	bucketCapacity = 1 << 3 //lobSize
+	bucketCapacity = 1 << 3
 	loadFactor     = 6.0
 )
 
@@ -71,13 +70,6 @@ func (h *HashMap) Get(key Key) Value {
 	// fmt.Printf("hashKey: 0x%016x / selectedBucket: %d / mashedHash: 0x%016x\n", hashkey, selectedBucket, maskedHash)
 
 	for b != nil {
-		// fmt.Printf("    entryCount: %d\n", b.entryCount)
-		// fmt.Printf("    entries: [\n")
-		// for i := uint64(0); i < uint64(b.entryCount); i++ {
-		// 	fmt.Printf("      [0x%016x,%s] -> %s\n", b.hobs.Read(i), b.entries[i].key, b.entries[i].value)
-		// }
-		// fmt.Printf("    ]\n")
-
 		for index := uint64(0); index < totalEntries; index++ {
 			// fmt.Printf("0x%016x <-> 0x%016x :: %s <-> %s\n", b.hobs.Read(index), maskedHash, b.entries[index].key, key)
 			if b.hobs.Read(index) == maskedHash && b.entries[index].key == key {
@@ -286,8 +278,6 @@ func createHashMap(size int, options *HashMapOptions) *HashMap {
 	lobSize := memory.PowerOf(initialSize)
 	lobMask := uint32(^(0xffffffff << lobSize))
 	buckets := make([]*bucket, initialSize)
-
-	// fmt.Printf("lobSize: %d; lobMask: 0x%032b\n", lobSize, lobMask)
 
 	src := rand.NewSource(time.Now().UnixNano())
 	random := rand.New(src)

--- a/hashmap.go
+++ b/hashmap.go
@@ -141,11 +141,10 @@ func (h *HashMap) Insert(key Key, value Value) (*HashMap, error) {
 	}
 
 	var result *HashMap
+	abort := make(chan struct{})
 	size := h.Size()
 	if matched {
 		result = createHashMap(size, h.options)
-
-		abort := make(chan struct{})
 		for kvp := range h.iterate(abort) {
 			insertValue := kvp.value
 			if kvp.key == key {
@@ -156,7 +155,6 @@ func (h *HashMap) Insert(key Key, value Value) (*HashMap, error) {
 	} else {
 		size++
 		result = createHashMap(size, h.options)
-		abort := make(chan struct{})
 		for kvp := range h.iterate(abort) {
 			result.internalSet(kvp.key, kvp.value)
 		}
@@ -232,13 +230,7 @@ func (h *HashMap) Size() int {
 }
 
 func (h *HashMap) instantiate(size int, contents []*keyValuePair) *BaseStruct {
-	var options *HashMapOptions
-	if h != nil {
-		options = h.options
-	} else {
-		options = NewHashMapOptions()
-	}
-	hash := createHashMap(size, options)
+	hash := createHashMap(size, h.options)
 
 	for _, v := range contents {
 		if v != nil {

--- a/hashmap.go
+++ b/hashmap.go
@@ -1,7 +1,6 @@
 package immutable
 
 import (
-	"fmt"
 	"math"
 	"math/rand"
 	"time"
@@ -68,19 +67,19 @@ func (h *HashMap) Get(key Key) Value {
 
 	totalEntries := uint64(b.entryCount)
 
-	fmt.Printf("\nlobSize: %d; h.lobMask: 0x%016x\n", h.lobSize, h.lobMask)
-	fmt.Printf("hashKey: 0x%016x / selectedBucket: %d / mashedHash: 0x%016x\n", hashkey, selectedBucket, maskedHash)
+	// fmt.Printf("\nlobSize: %d; h.lobMask: 0x%016x\n", h.lobSize, h.lobMask)
+	// fmt.Printf("hashKey: 0x%016x / selectedBucket: %d / mashedHash: 0x%016x\n", hashkey, selectedBucket, maskedHash)
 
 	for b != nil {
-		fmt.Printf("    entryCount: %d\n", b.entryCount)
-		fmt.Printf("    entries: [\n")
-		for i := uint64(0); i < uint64(b.entryCount); i++ {
-			fmt.Printf("      [0x%016x,%s] -> %s\n", b.hobs.Read(i), b.entries[i].key, b.entries[i].value)
-		}
-		fmt.Printf("    ]\n")
+		// fmt.Printf("    entryCount: %d\n", b.entryCount)
+		// fmt.Printf("    entries: [\n")
+		// for i := uint64(0); i < uint64(b.entryCount); i++ {
+		// 	fmt.Printf("      [0x%016x,%s] -> %s\n", b.hobs.Read(i), b.entries[i].key, b.entries[i].value)
+		// }
+		// fmt.Printf("    ]\n")
 
 		for index := uint64(0); index < totalEntries; index++ {
-			fmt.Printf("0x%016x <-> 0x%016x :: %s <-> %s\n", b.hobs.Read(index), maskedHash, b.entries[index].key, key)
+			// fmt.Printf("0x%016x <-> 0x%016x :: %s <-> %s\n", b.hobs.Read(index), maskedHash, b.entries[index].key, key)
 			if b.hobs.Read(index) == maskedHash && b.entries[index].key == key {
 				return b.entries[index].value
 			}
@@ -287,6 +286,8 @@ func createHashMap(size int, options *HashMapOptions) *HashMap {
 	lobSize := memory.PowerOf(initialSize)
 	lobMask := uint32(^(0xffffffff << lobSize))
 	buckets := make([]*bucket, initialSize)
+
+	// fmt.Printf("lobSize: %d; lobMask: 0x%032b\n", lobSize, lobMask)
 
 	src := rand.NewSource(time.Now().UnixNano())
 	random := rand.New(src)

--- a/hashmap.go
+++ b/hashmap.go
@@ -1,7 +1,10 @@
 package immutable
 
 import (
+	"fmt"
 	"math"
+	"math/rand"
+	"time"
 
 	"github.com/object88/immutable/memory"
 )
@@ -26,6 +29,7 @@ type HashMap struct {
 	buckets []*bucket
 	lobMask uint32
 	lobSize uint8
+	seed    uint32
 }
 
 const (
@@ -56,17 +60,28 @@ func (h *HashMap) Get(key Key) Value {
 		return nil
 	}
 
-	hashkey := key.Hash()
+	hashkey := key.Hash(h.seed)
 
-	selectedBucket := hashkey & h.lobMask
+	selectedBucket := hashkey & uint64(h.lobMask)
 	b := h.buckets[selectedBucket]
 	maskedHash := hashkey >> h.lobSize
 
 	totalEntries := uint64(b.entryCount)
 
+	fmt.Printf("\nlobSize: %d; h.lobMask: 0x%016x\n", h.lobSize, h.lobMask)
+	fmt.Printf("hashKey: 0x%016x / selectedBucket: %d / mashedHash: 0x%016x\n", hashkey, selectedBucket, maskedHash)
+
 	for b != nil {
+		fmt.Printf("    entryCount: %d\n", b.entryCount)
+		fmt.Printf("    entries: [\n")
+		for i := uint64(0); i < uint64(b.entryCount); i++ {
+			fmt.Printf("      [0x%016x,%s] -> %s\n", b.hobs.Read(i), b.entries[i].key, b.entries[i].value)
+		}
+		fmt.Printf("    ]\n")
+
 		for index := uint64(0); index < totalEntries; index++ {
-			if uint32(b.hobs.Read(index)) == maskedHash && b.entries[index].key == key {
+			fmt.Printf("0x%016x <-> 0x%016x :: %s <-> %s\n", b.hobs.Read(index), maskedHash, b.entries[index].key, key)
+			if b.hobs.Read(index) == maskedHash && b.entries[index].key == key {
 				return b.entries[index].value
 			}
 		}
@@ -244,26 +259,25 @@ func (h *HashMap) instantiate(size int, contents []*keyValuePair) *BaseStruct {
 }
 
 func (h *HashMap) internalSet(key Key, value Value) {
-	// lobSize := h.lobSize // uint32(memory.PowerOf(h.size))
-	hobSize := uint32(32 - h.lobSize)
+	hobSize := uint32(64 - h.lobSize)
 
-	hashkey := key.Hash()
-	selectedBucket := hashkey & h.lobMask
+	hashkey := key.Hash(h.seed)
+	selectedBucket := hashkey & uint64(h.lobMask)
 	// fmt.Printf("At [%s,%s]; h:0x%08x, sb: %d, lob: 0x%08x\n", key, value, hashkey, selectedBucket, hashkey>>h.lobSize)
 	b := h.buckets[selectedBucket]
 	if b == nil {
 		// Create the bucket.
-		b = createEmptyBucket(memory.LargeBlock, hobSize)
+		b = createEmptyBucket(h.options.BucketStrategy, hobSize)
 		h.buckets[selectedBucket] = b
 	}
 	for b.entryCount == 8 {
 		if b.overflow == nil {
-			b.overflow = createEmptyBucket(memory.LargeBlock, hobSize)
+			b.overflow = createEmptyBucket(h.options.BucketStrategy, hobSize)
 		}
 		b = b.overflow
 	}
 	b.entries[b.entryCount] = entry{key, value}
-	b.hobs.Assign(uint64(b.entryCount), uint64(hashkey>>h.lobSize))
+	b.hobs.Assign(uint64(b.entryCount), hashkey>>h.lobSize)
 	b.entryCount++
 }
 
@@ -274,7 +288,11 @@ func createHashMap(size int, options *HashMapOptions) *HashMap {
 	lobMask := uint32(^(0xffffffff << lobSize))
 	buckets := make([]*bucket, initialSize)
 
-	return &HashMap{options, initialCount, int(initialSize), buckets, lobMask, lobSize}
+	src := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(src)
+	seed := uint32(random.Int31())
+
+	return &HashMap{options, initialCount, int(initialSize), buckets, lobMask, lobSize, seed}
 }
 
 func createEmptyBucket(blockSize memory.BlockSize, hobSize uint32) *bucket {

--- a/hashmap_customkey_badhash_test.go
+++ b/hashmap_customkey_badhash_test.go
@@ -14,11 +14,11 @@ type MyBadKey struct {
 	value int
 }
 
-func (k MyBadKey) Hash() uint32 {
+func (k MyBadKey) Hash(seed uint32) uint64 {
 	if k.value%2 == 0 {
 		return 0x0
 	}
-	return 0xffffffff
+	return 0xffffffffffffffff
 }
 
 func (k MyBadKey) String() string {

--- a/hashmap_customkey_test.go
+++ b/hashmap_customkey_test.go
@@ -9,8 +9,8 @@ type MyKey struct {
 	value int
 }
 
-func (k MyKey) Hash() uint32 {
-	return uint32(k.value)
+func (k MyKey) Hash(seed uint32) uint64 {
+	return uint64(k.value)
 }
 
 func (k MyKey) String() string {

--- a/hashmap_gostringer.go
+++ b/hashmap_gostringer.go
@@ -22,8 +22,8 @@ func (h *HashMap) GoString() string {
 		buffer.WriteString(fmt.Sprintf("    entryCount: %d\n", b.entryCount))
 		buffer.WriteString("    entries: [\n")
 		for b != nil {
-			for i := uint32(0); i < uint32(b.entryCount); i++ {
-				buffer.WriteString(fmt.Sprintf("      [0x%08x,%s] -> %s\n", b.hobs.Read(uint64(i)), b.entries[i].key, b.entries[i].value))
+			for i := uint64(0); i < uint64(b.entryCount); i++ {
+				buffer.WriteString(fmt.Sprintf("      [0x%016x,%s] -> %s\n", b.hobs.Read(i), b.entries[i].key, b.entries[i].value))
 			}
 
 			b = b.overflow

--- a/hashmap_test.go
+++ b/hashmap_test.go
@@ -303,8 +303,12 @@ func Test_Hashmap_ReadAndWriteLargeDataSet(t *testing.T) {
 	}
 
 	original := NewHashMap(contents, nil)
-	for k, v := range contents {
+	// fmt.Printf("%#v\n", original)
+	// for k, v := range contents {
+	for i := 0; i < max; i++ {
+		k := IntKey(i)
 		result := original.Get(k)
+		v := contents[k]
 		if result != v {
 			t.Fatalf("At %s; expected %d, got %d\n", k, v, result)
 		}

--- a/hashmap_test.go
+++ b/hashmap_test.go
@@ -21,7 +21,6 @@ func Test_Hashmap(t *testing.T) {
 	if original.Size() != len(data) {
 		t.Fatalf("Incorrect size")
 	}
-	fmt.Println(original.String())
 	for k, v := range data {
 		result := original.Get(k)
 		if result != v {
@@ -303,8 +302,6 @@ func Test_Hashmap_ReadAndWriteLargeDataSet(t *testing.T) {
 	}
 
 	original := NewHashMap(contents, nil)
-	// fmt.Printf("%#v\n", original)
-	// for k, v := range contents {
 	for i := 0; i < max; i++ {
 		k := IntKey(i)
 		result := original.Get(k)

--- a/key.go
+++ b/key.go
@@ -1,9 +1,9 @@
 package immutable
 
 import (
-	"encoding/binary"
 	"fmt"
-	"hash/fnv"
+	"math/rand"
+	"time"
 )
 
 // IntKey is an integer-based Key
@@ -12,13 +12,42 @@ type IntKey int
 // StringKey is a string-based Key
 type StringKey string
 
-// Hash calculates the 32-bit hash
-func (k IntKey) Hash() uint32 {
-	hasher := fnv.New32a()
+// // Hash calculates the 32-bit hash
+// func (k IntKey) Hash() uint32 {
+// 	hasher := fnv.New32a()
+//
+// 	binary.Write(hasher, binary.LittleEndian, uint32(k))
+// 	hash := hasher.Sum32()
+// 	return hash
+// }
 
-	binary.Write(hasher, binary.LittleEndian, uint32(k))
-	hash := hasher.Sum32()
-	return hash
+const m1 = 194865226553
+const m2 = 24574600569641
+
+var hashkey [4]uintptr
+
+func init() {
+	src := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(src)
+	// getRandomData((*[len(hashkey) * sys.PtrSize]byte)(unsafe.Pointer(&hashkey))[:])
+	hashkey[0] = uintptr(random.Int63() | 1) // make sure these numbers are odd
+	hashkey[1] = uintptr(random.Int63() | 1)
+	hashkey[2] = uintptr(random.Int63() | 1)
+	hashkey[3] = uintptr(random.Int63() | 1)
+}
+
+// Hash does what Hash cannot.
+func (k IntKey) Hash(seed uint32) uint64 {
+	k1 := uint64(k)
+	h := uint64(uintptr(seed) + 8*hashkey[0])
+	h ^= (k1 & 0xffffffff)
+	h ^= (k1 & 0xffffffff00000000) << 32
+	h = rotl31(h*m1) * m2
+	return h
+}
+
+func rotl31(x uint64) uint64 {
+	return (x << 31) | (x >> (64 - 31))
 }
 
 func (k IntKey) String() string {

--- a/memory/constants.go
+++ b/memory/constants.go
@@ -1,9 +1,7 @@
 package memory
 
 const (
-	// allUint32bits = ^uint32(0)
 	bitsInExtraLargeBlock = 64
 	bitsInLargeBlock      = 32
 	bitsInSmallBlock      = 8
-	// bitsInBlock   = uint32(unsafe.Sizeof(uint32(0)) * bitsInSmallBlock)
 )

--- a/memory/memory32.go
+++ b/memory/memory32.go
@@ -1,7 +1,5 @@
 package memory
 
-import "fmt"
-
 const fullBlock = ^uint32(0)
 
 // Memories32 is all your memories.
@@ -12,45 +10,46 @@ type Memories32 struct {
 
 // Assign sets a value to the internal memory at the given index
 func (m *Memories32) Assign(index uint64, value uint64) {
-	bitsRemaining := uint64(m.bitsPerEntry)
-	offset := bitsRemaining * index
+	bitsRemaining := m.bitsPerEntry
+	offset := bitsRemaining * uint32(index)
 	byteOffset := offset / bitsInLargeBlock
 	bitOffset := offset % bitsInLargeBlock
 
-	fmt.Printf("\nAssigning %032b to index %d\n", value, index)
-	fmt.Printf("byteOffset: %d, bitOffset: %d, bitsRemaining: %d\n", byteOffset, bitOffset, bitsRemaining)
+	// fmt.Printf("\nAssigning %064b to index %d\n", value, index)
 
 	writeBitCount := bitsInLargeBlock - bitOffset
 	if writeBitCount > bitsRemaining {
 		writeBitCount = bitsRemaining
 	}
-	initial := uint64(m.m[byteOffset])
-	mask := uint64(fullBlock << writeBitCount)
-	result := (initial & ^(^mask << bitOffset)) | ((value & ^mask) << bitOffset)
-	m.m[byteOffset] = uint32(result)
+	// fmt.Printf("byteOffset: %d, bitOffset: %d, bitsRemaining: %d, writeBitCount: %d\n", byteOffset, bitOffset, bitsRemaining, writeBitCount)
+	initial := m.m[byteOffset]
+	mask := ^(fullExtraLargeBlock << writeBitCount)
+	result := uint32(value&mask)<<bitOffset | initial&^((^(fullBlock << writeBitCount))<<bitOffset)
+	m.m[byteOffset] = result
 
-	fmt.Printf("result at %d: %032b\n", byteOffset, m.m[byteOffset])
+	// fmt.Printf("result at %d: %032b ->  %032b\n", byteOffset, initial, result)
 
 	bitsRemaining -= writeBitCount
 	byteOffset++
 
-	if bitsRemaining > 32 {
-		o := (uint64(m.bitsPerEntry) - bitsRemaining)
-		result := ((value & (uint64(fullBlock) << o)) >> o)
-		m.m[byteOffset] = uint32(result)
-		fmt.Printf("result at %d: %032b\n", byteOffset, m.m[byteOffset])
+	if bitsRemaining >= 32 {
+		o := m.bitsPerEntry - bitsRemaining
+		result := uint32((value & (fullExtraLargeBlock << o)) >> o)
+		m.m[byteOffset] = result
+		// fmt.Printf("result at %d: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx ->  %032b\n", byteOffset, result)
 
 		bitsRemaining -= 32
 		byteOffset++
 	}
 
 	if bitsRemaining > 0 {
-		initial := uint64(m.m[byteOffset])
-		mask := uint64(fullBlock << bitsRemaining)
-		result := (initial & mask) | ((value & (^mask << writeBitCount)) >> writeBitCount)
-		m.m[byteOffset] = uint32(result)
+		writeBitCount = m.bitsPerEntry - bitsRemaining
+		initial := m.m[byteOffset]
+		mask := fullExtraLargeBlock << bitsRemaining
+		result := (initial & (fullBlock << bitsRemaining)) | uint32((value&((^mask)<<writeBitCount))>>writeBitCount)
+		m.m[byteOffset] = result
 
-		fmt.Printf("result at %d: %032b\n", byteOffset, m.m[byteOffset])
+		// fmt.Printf("result at %d: %032b ->  %032b\n", byteOffset, initial, result)
 	}
 }
 
@@ -60,36 +59,34 @@ func (m *Memories32) Read(index uint64) (result uint64) {
 	offset := bitsRemaining * index
 	bitOffset := offset % bitsInLargeBlock
 	byteOffset := offset / bitsInLargeBlock
-	fmt.Printf("\nbitOffset: %d, byteOffset: %d\n", bitOffset, byteOffset)
-	fmt.Printf("m.m: %x\n", m.m)
+	// fmt.Printf("\nbitOffset: %d, byteOffset: %d\n", bitOffset, byteOffset)
+	// fmt.Printf("m.m: %x\n", m.m)
 
 	readBitCount := bitsInLargeBlock - bitOffset
 	if readBitCount > bitsRemaining {
 		readBitCount = bitsRemaining
 	}
-	initial := uint64(m.m[byteOffset])
-	mask := uint64(^(fullBlock << readBitCount)) << bitOffset
+	initial := m.m[byteOffset]
+	mask := ^(fullBlock << readBitCount) << bitOffset
 	result = uint64((initial & mask) >> bitOffset)
 
 	bitsRemaining -= readBitCount
+	byteOffset++
 
-	if bitsRemaining > 0 {
-		readBitCount = bitsRemaining
-		if readBitCount > bitsInLargeBlock {
-			readBitCount = bitsInLargeBlock
-		}
-		fmt.Printf("--> %064b; %d; %d\n", result, bitsRemaining, readBitCount)
-		initial := uint64(m.m[byteOffset+1])
-		result |= ((initial & uint64(^(fullBlock << readBitCount))) << (uint64(m.bitsPerEntry) - bitsRemaining))
-		bitsRemaining -= readBitCount
+	if bitsRemaining >= 32 {
+		// fmt.Printf("--> %064b; %d; %d\n", result, bitsRemaining, 32)
+		initial := m.m[byteOffset]
+		result |= (uint64(initial) << (uint64(m.bitsPerEntry) - bitsRemaining))
+		bitsRemaining -= 32
+		byteOffset++
 	}
 
 	if bitsRemaining > 0 {
-		initial := uint64(m.m[byteOffset+2])
-		fmt.Printf("--> %064b; %d\n", result, bitsRemaining)
-		result |= ((initial & uint64(^(fullBlock << bitsRemaining))) << (uint64(m.bitsPerEntry) - bitsRemaining))
+		initial := m.m[byteOffset]
+		// fmt.Printf("--> %064b; %d\n", result, bitsRemaining)
+		result |= uint64(initial&(fullBlock>>(32-bitsRemaining))) << (uint64(m.bitsPerEntry) - bitsRemaining)
 	}
-	fmt.Printf("--> %064b\n", result)
+	// fmt.Printf("--> %064b\n", result)
 
 	return result
 }

--- a/memory/memory32.go
+++ b/memory/memory32.go
@@ -1,5 +1,7 @@
 package memory
 
+import "fmt"
+
 const fullBlock = ^uint32(0)
 
 // Memories32 is all your memories.
@@ -15,8 +17,8 @@ func (m *Memories32) Assign(index uint64, value uint64) {
 	byteOffset := offset / bitsInLargeBlock
 	bitOffset := offset % bitsInLargeBlock
 
-	// fmt.Printf("\nAssigning %032b to index %d\n", value, index)
-	// fmt.Printf("byteOffset: %d, bitOffset: %d, bitsRemaining: %d\n", byteOffset, bitOffset, bitsRemaining)
+	fmt.Printf("\nAssigning %032b to index %d\n", value, index)
+	fmt.Printf("byteOffset: %d, bitOffset: %d, bitsRemaining: %d\n", byteOffset, bitOffset, bitsRemaining)
 
 	writeBitCount := bitsInLargeBlock - bitOffset
 	if writeBitCount > bitsRemaining {
@@ -27,7 +29,7 @@ func (m *Memories32) Assign(index uint64, value uint64) {
 	result := (initial & ^(^mask << bitOffset)) | ((value & ^mask) << bitOffset)
 	m.m[byteOffset] = uint32(result)
 
-	// fmt.Printf("result at %d: %032b\n", byteOffset, m.m[byteOffset])
+	fmt.Printf("result at %d: %032b\n", byteOffset, m.m[byteOffset])
 
 	bitsRemaining -= writeBitCount
 	byteOffset++
@@ -36,7 +38,7 @@ func (m *Memories32) Assign(index uint64, value uint64) {
 		o := (uint64(m.bitsPerEntry) - bitsRemaining)
 		result := ((value & (uint64(fullBlock) << o)) >> o)
 		m.m[byteOffset] = uint32(result)
-		// fmt.Printf("result at %d: %032b\n", byteOffset, m.m[byteOffset])
+		fmt.Printf("result at %d: %032b\n", byteOffset, m.m[byteOffset])
 
 		bitsRemaining -= 32
 		byteOffset++
@@ -48,7 +50,7 @@ func (m *Memories32) Assign(index uint64, value uint64) {
 		result := (initial & mask) | ((value & (^mask << writeBitCount)) >> writeBitCount)
 		m.m[byteOffset] = uint32(result)
 
-		// fmt.Printf("result at %d: %032b\n", byteOffset, m.m[byteOffset])
+		fmt.Printf("result at %d: %032b\n", byteOffset, m.m[byteOffset])
 	}
 }
 
@@ -58,8 +60,8 @@ func (m *Memories32) Read(index uint64) (result uint64) {
 	offset := bitsRemaining * index
 	bitOffset := offset % bitsInLargeBlock
 	byteOffset := offset / bitsInLargeBlock
-	// fmt.Printf("\nbitOffset: %d, byteOffset: %d\n", bitOffset, byteOffset)
-	// fmt.Printf("m.m: %x\n", m.m)
+	fmt.Printf("\nbitOffset: %d, byteOffset: %d\n", bitOffset, byteOffset)
+	fmt.Printf("m.m: %x\n", m.m)
 
 	readBitCount := bitsInLargeBlock - bitOffset
 	if readBitCount > bitsRemaining {
@@ -76,7 +78,7 @@ func (m *Memories32) Read(index uint64) (result uint64) {
 		if readBitCount > bitsInLargeBlock {
 			readBitCount = bitsInLargeBlock
 		}
-		// fmt.Printf("--> %064b; %d; %d\n", result, bitsRemaining, readBitCount)
+		fmt.Printf("--> %064b; %d; %d\n", result, bitsRemaining, readBitCount)
 		initial := uint64(m.m[byteOffset+1])
 		result |= ((initial & uint64(^(fullBlock << readBitCount))) << (uint64(m.bitsPerEntry) - bitsRemaining))
 		bitsRemaining -= readBitCount
@@ -84,10 +86,10 @@ func (m *Memories32) Read(index uint64) (result uint64) {
 
 	if bitsRemaining > 0 {
 		initial := uint64(m.m[byteOffset+2])
-		// fmt.Printf("--> %064b; %d\n", result, bitsRemaining)
+		fmt.Printf("--> %064b; %d\n", result, bitsRemaining)
 		result |= ((initial & uint64(^(fullBlock << bitsRemaining))) << (uint64(m.bitsPerEntry) - bitsRemaining))
 	}
-	// fmt.Printf("--> %064b\n", result)
+	fmt.Printf("--> %064b\n", result)
 
 	return result
 }

--- a/memory/memory32_test.go
+++ b/memory/memory32_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 	"testing"
@@ -55,61 +56,90 @@ func evaluateLargeRead(t *testing.T, bitCount, count uint32, readIndex, expected
 }
 
 func Test_Large_Assign(t *testing.T) {
-	evaluateLargeAssign(t, 4, 1, 0, 0x000000000000000f, memoryMap32{0: 0x0000000f}, nil)
-	evaluateLargeAssign(t, 4, 2, 1, 0x000000000000000f, memoryMap32{0: 0x000000f0}, nil)
-	evaluateLargeAssign(t, 4, 3, 2, 0x000000000000000f, memoryMap32{0: 0x00000f00}, nil)
-	evaluateLargeAssign(t, 6, 2, 1, 0x000000000000003f, memoryMap32{0: 0x00000fc0}, nil)
-	evaluateLargeAssign(t, 11, 2, 1, 0x00000000000007ff, memoryMap32{0: 0x003ff800}, nil)
-	evaluateLargeAssign(t, 24, 2, 1, 0x0000000000ffffff, memoryMap32{0: 0xff000000, 1: 0xffff}, nil)
-	evaluateLargeAssign(t, 31, 1, 0, 0x000000002aaaaaaa, memoryMap32{0: 0x2aaaaaaa}, nil)
-	evaluateLargeAssign(t, 31, 1, 0, 0x0000000055555555, memoryMap32{0: 0x55555555}, nil)
-	evaluateLargeAssign(t, 31, 1, 0, 0x000000007fffffff, memoryMap32{0: 0x7fffffff}, nil)
-	evaluateLargeAssign(t, 31, 2, 1, 0x000000002aaaaaaa, memoryMap32{1: 0x15555555}, nil)
-	evaluateLargeAssign(t, 31, 2, 1, 0x0000000055555555, memoryMap32{0: 0x80000000, 1: 0x2aaaaaaa}, nil)
-	evaluateLargeAssign(t, 31, 2, 1, 0x000000007fffffff, memoryMap32{0: 0x80000000, 1: 0x3fffffff}, nil)
-	evaluateLargeAssign(t, 32, 1, 0, 0x0000000055555555, memoryMap32{0: 0x55555555}, nil)
-	evaluateLargeAssign(t, 32, 1, 0, 0x00000000aaaaaaaa, memoryMap32{0: 0xaaaaaaaa}, nil)
-	evaluateLargeAssign(t, 32, 1, 0, 0x00000000ffffffff, memoryMap32{0: 0xffffffff}, nil)
-	evaluateLargeAssign(t, 32, 2, 1, 0x0000000055555555, memoryMap32{1: 0x55555555}, nil)
-	evaluateLargeAssign(t, 32, 2, 1, 0x00000000aaaaaaaa, memoryMap32{1: 0xaaaaaaaa}, nil)
-	evaluateLargeAssign(t, 32, 2, 1, 0x00000000ffffffff, memoryMap32{1: 0xffffffff}, nil)
-	evaluateLargeAssign(t, 63, 1, 0, 0x5555555555555555, memoryMap32{0: 0x55555555, 1: 0x55555555}, nil)
-	evaluateLargeAssign(t, 63, 1, 0, 0x2aaaaaaaaaaaaaaa, memoryMap32{0: 0xaaaaaaaa, 1: 0x2aaaaaaa}, nil)
-	evaluateLargeAssign(t, 63, 1, 0, 0x7fffffffffffffff, memoryMap32{0: 0xffffffff, 1: 0x7fffffff}, nil)
-	evaluateLargeAssign(t, 63, 2, 1, 0x5555555555555555, memoryMap32{1: 0x80000000, 2: 0xaaaaaaaa, 3: 0x2aaaaaaa}, nil)
-	evaluateLargeAssign(t, 63, 2, 1, 0x2aaaaaaaaaaaaaaa, memoryMap32{2: 0x55555555, 3: 0x15555555}, nil)
-	evaluateLargeAssign(t, 63, 2, 1, 0x7fffffffffffffff, memoryMap32{1: 0x80000000, 2: 0xffffffff, 3: 0x3fffffff}, nil)
-	evaluateLargeAssign(t, 64, 2, 1, 0x5555555555555555, memoryMap32{2: 0x55555555, 3: 0x55555555}, nil)
-	evaluateLargeAssign(t, 64, 2, 1, 0xaaaaaaaaaaaaaaaa, memoryMap32{2: 0xaaaaaaaa, 3: 0xaaaaaaaa}, nil)
-	evaluateLargeAssign(t, 64, 2, 1, 0xffffffffffffffff, memoryMap32{2: 0xffffffff, 3: 0xffffffff}, nil)
-
 	o := &assignOptions{true}
-	evaluateLargeAssign(t, 4, 1, 0, 0x0, memoryMap32{0: 0xfffffff0}, o)
-	evaluateLargeAssign(t, 4, 2, 1, 0x0, memoryMap32{0: 0xffffff0f}, o)
-	evaluateLargeAssign(t, 4, 3, 2, 0x0, memoryMap32{0: 0xfffff0ff}, o)
-	evaluateLargeAssign(t, 6, 2, 1, 0x0, memoryMap32{0: 0xfffff03f}, o)
-	evaluateLargeAssign(t, 11, 2, 1, 0x0, memoryMap32{0: 0xffc007ff}, o)
-	evaluateLargeAssign(t, 24, 2, 1, 0x0, memoryMap32{0: 0x00ffffff, 1: 0xffff0000}, o)
-	evaluateLargeAssign(t, 31, 1, 0, 0x0, memoryMap32{0: 0x80000000}, o)
-	evaluateLargeAssign(t, 31, 2, 1, 0x0, memoryMap32{0: 0x7fffffff, 1: 0xc0000000}, o)
+
+	testCases := []struct {
+		bitCount   uint32
+		count      uint32
+		writeIndex uint64
+		value      uint64
+		assessment memoryMap32
+		options    *assignOptions
+	}{
+		{4, 1, 0, 0x000000000000000f, memoryMap32{0: 0x0000000f}, nil},
+		{4, 2, 1, 0x000000000000000f, memoryMap32{0: 0x000000f0}, nil},
+		{4, 3, 2, 0x000000000000000f, memoryMap32{0: 0x00000f00}, nil},
+		{6, 2, 1, 0x000000000000003f, memoryMap32{0: 0x00000fc0}, nil},
+		{11, 2, 1, 0x00000000000007ff, memoryMap32{0: 0x003ff800}, nil},
+		{24, 2, 1, 0x0000000000ffffff, memoryMap32{0: 0xff000000, 1: 0xffff}, nil},
+		{31, 1, 0, 0x000000002aaaaaaa, memoryMap32{0: 0x2aaaaaaa}, nil},
+		{31, 1, 0, 0x0000000055555555, memoryMap32{0: 0x55555555}, nil},
+		{31, 1, 0, 0x000000007fffffff, memoryMap32{0: 0x7fffffff}, nil},
+		{31, 2, 1, 0x000000002aaaaaaa, memoryMap32{1: 0x15555555}, nil},
+		{31, 2, 1, 0x0000000055555555, memoryMap32{0: 0x80000000, 1: 0x2aaaaaaa}, nil},
+		{31, 2, 1, 0x000000007fffffff, memoryMap32{0: 0x80000000, 1: 0x3fffffff}, nil},
+		{32, 1, 0, 0x0000000055555555, memoryMap32{0: 0x55555555}, nil},
+		{32, 1, 0, 0x00000000aaaaaaaa, memoryMap32{0: 0xaaaaaaaa}, nil},
+		{32, 1, 0, 0x00000000ffffffff, memoryMap32{0: 0xffffffff}, nil},
+		{32, 2, 1, 0x0000000055555555, memoryMap32{1: 0x55555555}, nil},
+		{32, 2, 1, 0x00000000aaaaaaaa, memoryMap32{1: 0xaaaaaaaa}, nil},
+		{32, 2, 1, 0x00000000ffffffff, memoryMap32{1: 0xffffffff}, nil},
+		{63, 1, 0, 0x5555555555555555, memoryMap32{0: 0x55555555, 1: 0x55555555}, nil},
+		{63, 1, 0, 0x2aaaaaaaaaaaaaaa, memoryMap32{0: 0xaaaaaaaa, 1: 0x2aaaaaaa}, nil},
+		{63, 1, 0, 0x7fffffffffffffff, memoryMap32{0: 0xffffffff, 1: 0x7fffffff}, nil},
+		{63, 2, 1, 0x5555555555555555, memoryMap32{1: 0x80000000, 2: 0xaaaaaaaa, 3: 0x2aaaaaaa}, nil},
+		{63, 2, 1, 0x2aaaaaaaaaaaaaaa, memoryMap32{2: 0x55555555, 3: 0x15555555}, nil},
+		{63, 2, 1, 0x7fffffffffffffff, memoryMap32{1: 0x80000000, 2: 0xffffffff, 3: 0x3fffffff}, nil},
+		{64, 2, 1, 0x5555555555555555, memoryMap32{2: 0x55555555, 3: 0x55555555}, nil},
+		{64, 2, 1, 0xaaaaaaaaaaaaaaaa, memoryMap32{2: 0xaaaaaaaa, 3: 0xaaaaaaaa}, nil},
+		{64, 2, 1, 0xffffffffffffffff, memoryMap32{2: 0xffffffff, 3: 0xffffffff}, nil},
+
+		{4, 1, 0, 0x0, memoryMap32{0: 0xfffffff0}, o},
+		{4, 2, 1, 0x0, memoryMap32{0: 0xffffff0f}, o},
+		{4, 3, 2, 0x0, memoryMap32{0: 0xfffff0ff}, o},
+		{6, 2, 1, 0x0, memoryMap32{0: 0xfffff03f}, o},
+		{11, 2, 1, 0x0, memoryMap32{0: 0xffc007ff}, o},
+		{24, 2, 1, 0x0, memoryMap32{0: 0x00ffffff, 1: 0xffff0000}, o},
+		{31, 1, 0, 0x0, memoryMap32{0: 0x80000000}, o},
+		{31, 2, 1, 0x0, memoryMap32{0: 0x7fffffff, 1: 0xc0000000}, o},
+	}
+
+	for index, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", index), func(t *testing.T) {
+			m := AllocateMemories(LargeBlock, tc.bitCount, tc.count)
+			mem := m.(*Memories32).m
+			if tc.options != nil && tc.options.initInvert {
+				for k := range mem {
+					mem[k] = 0xffffffff
+				}
+			}
+			m.Assign(tc.writeIndex, tc.value)
+			for k, v := range tc.assessment {
+				result := uint32(mem[k])
+				if v != result {
+					t.Fatalf("At %d, incorrect result from write; expected 0x%08x, got 0x%08x\n", k, v, result)
+				}
+			}
+		})
+	}
 }
 
-func evaluateLargeAssign(t *testing.T, bitCount, count uint32, writeIndex, value uint64, assessment memoryMap32, options *assignOptions) {
-	m := AllocateMemories(LargeBlock, bitCount, count)
-	mem := m.(*Memories32).m
-	if options != nil && options.initInvert {
-		for k := range mem {
-			mem[k] = 0xffffffff
-		}
-	}
-	m.Assign(writeIndex, value)
-	for k, v := range assessment {
-		result := uint32(mem[k])
-		if v != result {
-			t.Fatalf("At %d, incorrect result from write; expected 0x%016x, got 0x%016x\n", k, v, result)
-		}
-	}
-}
+// func evaluateLargeAssign(t *testing.T, bitCount, count uint32, writeIndex, value uint64, assessment memoryMap32, options *assignOptions) {
+// 	m := AllocateMemories(LargeBlock, bitCount, count)
+// 	mem := m.(*Memories32).m
+// 	if options != nil && options.initInvert {
+// 		for k := range mem {
+// 			mem[k] = 0xffffffff
+// 		}
+// 	}
+// 	m.Assign(writeIndex, value)
+// 	for k, v := range assessment {
+// 		result := uint32(mem[k])
+// 		if v != result {
+// 			t.Fatalf("At %d, incorrect result from write; expected 0x%016x, got 0x%016x\n", k, v, result)
+// 		}
+// 	}
+// }
 
 func Test_Large_Random(t *testing.T) {
 	src := rand.NewSource(time.Now().UnixNano())
@@ -118,13 +148,13 @@ func Test_Large_Random(t *testing.T) {
 	width := uint32(64 - 11)
 	max := int64(math.Pow(2.0, float64(width)))
 
-	count := uint64(8)
+	count := 8
 	contents := make([]uint64, count)
-	for i := uint64(0); i < count; i++ {
+	for i := 0; i < count; i++ {
 		contents[i] = uint64(random.Int63n(max))
 	}
 
-	m := AllocateMemories(LargeBlock, width, 8)
+	m := AllocateMemories(LargeBlock, width, uint32(count))
 	for k, v := range contents {
 		m.Assign(uint64(k), v)
 	}
@@ -136,46 +166,3 @@ func Test_Large_Random(t *testing.T) {
 		}
 	}
 }
-
-// func Test_WriteAndRead2(t *testing.T) {
-// 	count := 4
-// 	set := make([]uint64, count)
-// 	for i := 0; i < count; i++ {
-// 		set[i] = 0x55555555
-// 	}
-//
-// 	m := AllocateMemories(LargeBlock, 31, 4)
-//
-// 	for k, v := range set {
-// 		m.Assign(uint64(k), v)
-// 	}
-//
-// 	for k, v := range set {
-// 		result := m.Read(uint64(k))
-// 		if result != v {
-// 			t.Fatalf("At %d\nexpected %032b\nreceived %032b\n", k, v, result)
-// 		}
-// 	}
-// }
-//
-// func Test_WriteAndRead(t *testing.T) {
-// 	count := 4
-// 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-// 	set := make([]uint64, count)
-// 	for i := 0; i < count; i++ {
-// 		set[i] = uint64(r.Int31()) & 0x7fffffff
-// 	}
-//
-// 	m := AllocateMemories(LargeBlock, 31, 4)
-//
-// 	for k, v := range set {
-// 		m.Assign(uint64(k), v)
-// 	}
-//
-// 	for k, v := range set {
-// 		result := m.Read(uint64(k))
-// 		if result != v {
-// 			t.Fatalf("At %d\nexpected %032b\nreceived %032b\n", k, v, result)
-// 		}
-// 	}
-// }

--- a/memory/memory32_test.go
+++ b/memory/memory32_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"math"
 	"math/rand"
 	"testing"
 	"time"
@@ -110,45 +111,71 @@ func evaluateLargeAssign(t *testing.T, bitCount, count uint32, writeIndex, value
 	}
 }
 
-func Test_WriteAndRead2(t *testing.T) {
-	count := 4
-	set := make([]uint64, count)
-	for i := 0; i < count; i++ {
-		set[i] = 0x55555555
+func Test_Large_Random(t *testing.T) {
+	src := rand.NewSource(time.Now().UnixNano())
+	random := rand.New(src)
+
+	width := uint32(64 - 11)
+	max := int64(math.Pow(2.0, float64(width)))
+
+	count := uint64(8)
+	contents := make([]uint64, count)
+	for i := uint64(0); i < count; i++ {
+		contents[i] = uint64(random.Int63n(max))
 	}
 
-	m := AllocateMemories(LargeBlock, 31, 4)
-
-	for k, v := range set {
+	m := AllocateMemories(LargeBlock, width, 8)
+	for k, v := range contents {
 		m.Assign(uint64(k), v)
 	}
 
-	for k, v := range set {
+	for k, v := range contents {
 		result := m.Read(uint64(k))
 		if result != v {
-			t.Fatalf("At %d\nexpected %032b\nreceived %032b\n", k, v, result)
+			t.Fatalf("At %d\nexpected %064b\nreceived %064b\n", k, v, result)
 		}
 	}
 }
 
-func Test_WriteAndRead(t *testing.T) {
-	count := 4
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-	set := make([]uint64, count)
-	for i := 0; i < count; i++ {
-		set[i] = uint64(r.Int31()) & 0x7fffffff
-	}
-
-	m := AllocateMemories(LargeBlock, 31, 4)
-
-	for k, v := range set {
-		m.Assign(uint64(k), v)
-	}
-
-	for k, v := range set {
-		result := m.Read(uint64(k))
-		if result != v {
-			t.Fatalf("At %d\nexpected %032b\nreceived %032b\n", k, v, result)
-		}
-	}
-}
+// func Test_WriteAndRead2(t *testing.T) {
+// 	count := 4
+// 	set := make([]uint64, count)
+// 	for i := 0; i < count; i++ {
+// 		set[i] = 0x55555555
+// 	}
+//
+// 	m := AllocateMemories(LargeBlock, 31, 4)
+//
+// 	for k, v := range set {
+// 		m.Assign(uint64(k), v)
+// 	}
+//
+// 	for k, v := range set {
+// 		result := m.Read(uint64(k))
+// 		if result != v {
+// 			t.Fatalf("At %d\nexpected %032b\nreceived %032b\n", k, v, result)
+// 		}
+// 	}
+// }
+//
+// func Test_WriteAndRead(t *testing.T) {
+// 	count := 4
+// 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+// 	set := make([]uint64, count)
+// 	for i := 0; i < count; i++ {
+// 		set[i] = uint64(r.Int31()) & 0x7fffffff
+// 	}
+//
+// 	m := AllocateMemories(LargeBlock, 31, 4)
+//
+// 	for k, v := range set {
+// 		m.Assign(uint64(k), v)
+// 	}
+//
+// 	for k, v := range set {
+// 		result := m.Read(uint64(k))
+// 		if result != v {
+// 			t.Fatalf("At %d\nexpected %032b\nreceived %032b\n", k, v, result)
+// 		}
+// 	}
+// }

--- a/memory/memory64_test.go
+++ b/memory/memory64_test.go
@@ -1,6 +1,7 @@
 package memory
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 	"testing"
@@ -8,76 +9,100 @@ import (
 )
 
 func Test_ExtraLarge_Read(t *testing.T) {
-	evaluateExtraLargeRead(t, 4, 1, 0, 0xf, memoryMap64{0: 0xf}, nil)
-	evaluateExtraLargeRead(t, 4, 16, 0, 0xf, memoryMap64{0: 0xf}, nil)
-	evaluateExtraLargeRead(t, 4, 32, 0, 0xf, memoryMap64{0: 0xf}, nil)
-	evaluateExtraLargeRead(t, 4, 32, 1, 0xf, memoryMap64{0: 0xf0}, nil)
-	evaluateExtraLargeRead(t, 4, 32, 15, 0x000000000000000f, memoryMap64{0: 0xf000000000000000}, nil)
-	evaluateExtraLargeRead(t, 4, 32, 16, 0x000000000000000f, memoryMap64{1: 0x000000000000000f}, nil)
-	evaluateExtraLargeRead(t, 4, 32, 31, 0x000000000000000f, memoryMap64{1: 0xf000000000000000}, nil)
-	evaluateExtraLargeRead(t, 8, 32, 0, 0x00000000000000ff, memoryMap64{0: 0x00000000000000ff}, nil)
-	evaluateExtraLargeRead(t, 8, 32, 1, 0x00000000000000ff, memoryMap64{0: 0x000000000000ff00}, nil)
-	evaluateExtraLargeRead(t, 31, 1, 0, 0x000000007fffffff, memoryMap64{0: 0x000000007fffffff}, nil)
-	evaluateExtraLargeRead(t, 31, 4, 1, 0x000000007fffffff, memoryMap64{0: 0x3fffffff80000000}, nil)
-	evaluateExtraLargeRead(t, 31, 4, 2, 0x000000007fffffff, memoryMap64{0: 0xc000000000000000, 1: 0x000000001fffffff}, nil)
-	evaluateExtraLargeRead(t, 63, 4, 0, 0x7fffffffffffffff, memoryMap64{0: 0x7fffffffffffffff}, nil)
-	evaluateExtraLargeRead(t, 63, 4, 1, 0x7fffffffffffffff, memoryMap64{0: 0x8000000000000000, 1: 0x3fffffffffffffff}, nil)
-	evaluateExtraLargeRead(t, 63, 4, 2, 0x7fffffffffffffff, memoryMap64{1: 0xc000000000000000, 2: 0x1fffffffffffffff}, nil)
-	// Need more here, with 555..., and aaa...
-	// Also need some with bits flipped; writing 0s.
-}
+	// o := &readOptions{true}
 
-func evaluateExtraLargeRead(t *testing.T, bitCount, count uint32, readIndex, expected uint64, assignment memoryMap64, options *readOptions) {
-	// fmt.Printf("\nReviewing %d/%d/0x%08x\n", bitCount, count, expected)
-	m := AllocateMemories(ExtraLargeBlock, bitCount, count)
-	mem := m.(*Memories64).m
-	if options != nil && options.initInvert {
-		for k := range mem {
-			mem[k] = 0xffffffffffffffff
-		}
+	testCases := []struct {
+		bitCount   uint32
+		count      uint32
+		readIndex  uint64
+		expected   uint64
+		assignment memoryMap64
+		options    *readOptions
+	}{
+		{4, 1, 0, 0xf, memoryMap64{0: 0xf}, nil},
+		{4, 16, 0, 0xf, memoryMap64{0: 0xf}, nil},
+		{4, 32, 0, 0xf, memoryMap64{0: 0xf}, nil},
+		{4, 32, 1, 0xf, memoryMap64{0: 0xf0}, nil},
+		{4, 32, 15, 0x000000000000000f, memoryMap64{0: 0xf000000000000000}, nil},
+		{4, 32, 16, 0x000000000000000f, memoryMap64{1: 0x000000000000000f}, nil},
+		{4, 32, 31, 0x000000000000000f, memoryMap64{1: 0xf000000000000000}, nil},
+		{8, 32, 0, 0x00000000000000ff, memoryMap64{0: 0x00000000000000ff}, nil},
+		{8, 32, 1, 0x00000000000000ff, memoryMap64{0: 0x000000000000ff00}, nil},
+		{31, 1, 0, 0x000000007fffffff, memoryMap64{0: 0x000000007fffffff}, nil},
+		{31, 4, 1, 0x000000007fffffff, memoryMap64{0: 0x3fffffff80000000}, nil},
+		{31, 4, 2, 0x000000007fffffff, memoryMap64{0: 0xc000000000000000, 1: 0x000000001fffffff}, nil},
+		{63, 4, 0, 0x7fffffffffffffff, memoryMap64{0: 0x7fffffffffffffff}, nil},
+		{63, 4, 1, 0x7fffffffffffffff, memoryMap64{0: 0x8000000000000000, 1: 0x3fffffffffffffff}, nil},
+		{63, 4, 2, 0x7fffffffffffffff, memoryMap64{1: 0xc000000000000000, 2: 0x1fffffffffffffff}, nil},
+		// Need more here, with 555..., and aaa...
+		// Also need some with bits flipped; writing 0s.
 	}
-	for k, v := range assignment {
-		// fmt.Printf("Writing 0x%08x to %d\n", v, k)
-		mem[k] = uint64(v)
-	}
-	result := m.Read(readIndex)
-	if result != expected {
-		t.Fatalf("Incorrect result from read; expected 0x%016x, got 0x%016x\n", expected, result)
+
+	for index, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", index), func(t *testing.T) {
+			// fmt.Printf("\nReviewing %d/%d/0x%08x\n", bitCount, count, expected)
+			m := AllocateMemories(ExtraLargeBlock, tc.bitCount, tc.count)
+			mem := m.(*Memories64).m
+			if tc.options != nil && tc.options.initInvert {
+				for k := range mem {
+					mem[k] = 0xffffffffffffffff
+				}
+			}
+			for k, v := range tc.assignment {
+				// fmt.Printf("Writing 0x%08x to %d\n", v, k)
+				mem[k] = uint64(v)
+			}
+			result := m.Read(tc.readIndex)
+			if result != tc.expected {
+				t.Fatalf("Incorrect result from read; expected 0x%016x, got 0x%016x\n", tc.expected, result)
+			}
+		})
 	}
 }
 
 func Test_ExtraLarge_Assign(t *testing.T) {
-	evaluateExtraLargeAssign(t, 4, 1, 0, 0xf, memoryMap64{0: 0xf}, nil)
-	evaluateExtraLargeAssign(t, 4, 16, 0, 0xf, memoryMap64{0: 0xf}, nil)
-	evaluateExtraLargeAssign(t, 4, 32, 0, 0xf, memoryMap64{0: 0xf}, nil)
-	evaluateExtraLargeAssign(t, 4, 32, 1, 0xf, memoryMap64{0: 0xf0}, nil)
-	evaluateExtraLargeAssign(t, 4, 32, 15, 0x000000000000000f, memoryMap64{0: 0xf000000000000000}, nil)
-	evaluateExtraLargeAssign(t, 4, 32, 16, 0x000000000000000f, memoryMap64{1: 0x000000000000000f}, nil)
-	evaluateExtraLargeAssign(t, 4, 32, 31, 0x000000000000000f, memoryMap64{1: 0xf000000000000000}, nil)
-	evaluateExtraLargeAssign(t, 8, 32, 0, 0x00000000000000ff, memoryMap64{0: 0x00000000000000ff}, nil)
-	evaluateExtraLargeAssign(t, 8, 32, 1, 0x00000000000000ff, memoryMap64{0: 0x000000000000ff00}, nil)
-	evaluateExtraLargeAssign(t, 31, 1, 0, 0x000000007fffffff, memoryMap64{0: 0x000000007fffffff}, nil)
-	evaluateExtraLargeAssign(t, 31, 4, 1, 0x000000007fffffff, memoryMap64{0: 0x3fffffff80000000}, nil)
-	evaluateExtraLargeAssign(t, 31, 4, 2, 0x000000007fffffff, memoryMap64{0: 0xc000000000000000, 1: 0x000000001fffffff}, nil)
-	evaluateExtraLargeAssign(t, 63, 4, 0, 0x7fffffffffffffff, memoryMap64{0: 0x7fffffffffffffff}, nil)
-	evaluateExtraLargeAssign(t, 63, 4, 1, 0x7fffffffffffffff, memoryMap64{0: 0x8000000000000000, 1: 0x3fffffffffffffff}, nil)
-	evaluateExtraLargeAssign(t, 63, 4, 2, 0x7fffffffffffffff, memoryMap64{1: 0xc000000000000000, 2: 0x1fffffffffffffff}, nil)
-}
-
-func evaluateExtraLargeAssign(t *testing.T, bitCount, count uint32, writeIndex, value uint64, assessment memoryMap64, options *assignOptions) {
-	m := AllocateMemories(ExtraLargeBlock, bitCount, count)
-	mem := m.(*Memories64).m
-	if options != nil && options.initInvert {
-		for k := range mem {
-			mem[k] = 0xffffffffffffffff
-		}
+	testCases := []struct {
+		bitCount   uint32
+		count      uint32
+		writeIndex uint64
+		expected   uint64
+		assignment memoryMap64
+		options    *readOptions
+	}{
+		{4, 1, 0, 0xf, memoryMap64{0: 0xf}, nil},
+		{4, 16, 0, 0xf, memoryMap64{0: 0xf}, nil},
+		{4, 32, 0, 0xf, memoryMap64{0: 0xf}, nil},
+		{4, 32, 1, 0xf, memoryMap64{0: 0xf0}, nil},
+		{4, 32, 15, 0x000000000000000f, memoryMap64{0: 0xf000000000000000}, nil},
+		{4, 32, 16, 0x000000000000000f, memoryMap64{1: 0x000000000000000f}, nil},
+		{4, 32, 31, 0x000000000000000f, memoryMap64{1: 0xf000000000000000}, nil},
+		{8, 32, 0, 0x00000000000000ff, memoryMap64{0: 0x00000000000000ff}, nil},
+		{8, 32, 1, 0x00000000000000ff, memoryMap64{0: 0x000000000000ff00}, nil},
+		{31, 1, 0, 0x000000007fffffff, memoryMap64{0: 0x000000007fffffff}, nil},
+		{31, 4, 1, 0x000000007fffffff, memoryMap64{0: 0x3fffffff80000000}, nil},
+		{31, 4, 2, 0x000000007fffffff, memoryMap64{0: 0xc000000000000000, 1: 0x000000001fffffff}, nil},
+		{63, 4, 0, 0x7fffffffffffffff, memoryMap64{0: 0x7fffffffffffffff}, nil},
+		{63, 4, 1, 0x7fffffffffffffff, memoryMap64{0: 0x8000000000000000, 1: 0x3fffffffffffffff}, nil},
+		{63, 4, 2, 0x7fffffffffffffff, memoryMap64{1: 0xc000000000000000, 2: 0x1fffffffffffffff}, nil},
 	}
-	m.Assign(writeIndex, value)
-	for k, v := range assessment {
-		result := uint64(mem[k])
-		if v != result {
-			t.Fatalf("At %d, incorrect result from write; expected 0x%016x, got 0x%016x\n", k, v, result)
-		}
+
+	for index, tc := range testCases {
+		t.Run(fmt.Sprintf("%d", index), func(t *testing.T) {
+			m := AllocateMemories(ExtraLargeBlock, tc.bitCount, tc.count)
+			mem := m.(*Memories64).m
+			if tc.options != nil && tc.options.initInvert {
+				for k := range mem {
+					mem[k] = 0xffffffffffffffff
+				}
+			}
+			m.Assign(tc.writeIndex, tc.expected)
+			for k, v := range tc.assignment {
+				result := uint64(mem[k])
+				if v != result {
+					t.Fatalf("At %d, incorrect result from write; expected 0x%016x, got 0x%016x\n", k, v, result)
+				}
+			}
+		})
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -13,7 +13,7 @@ type Key interface {
 	fmt.Stringer
 
 	// Hash calculates the 32-bit hash value for a Key
-	Hash() uint32
+	Hash(seed uint32) uint64
 }
 
 // MapPredicate describes the predicate function used by the Map method


### PR DESCRIPTION
In a `Get` function in hashmap, calculating a key's hash takes roughly 30% CPU time.  This PR replaces hash function to see if swapping it out with something based on the hashing method used internally for `map`, can improve performance.

See #32 , #33 