### PR TITLE
Common empty map

### DIFF
--- a/core/hashmap_options.go
+++ b/core/hashmap_options.go
@@ -2,28 +2,26 @@ package core
 
 import "github.com/object88/immutable/memory"
 
-// HashMapOption can be implemented to set a hash map option using the
+// HashmapOption can be implemented to set a hash map option using the
 // NewHashMap function
-type HashMapOption func(*HashMapOptions)
+type HashmapOption func(*HashmapOptions)
 
 // WithBucketStrategy selects a bucket strategy for the hash map
-func WithBucketStrategy(blocksize memory.BlockSize) HashMapOption {
-	return func(o *HashMapOptions) {
+func WithBucketStrategy(blocksize memory.BlockSize) HashmapOption {
+	return func(o *HashmapOptions) {
 		o.BucketStrategy = blocksize
 	}
 }
 
-// HashMapOptions contains the options which select the strategies used by
+// HashmapOptions contains the options which select the strategies used by
 // a hash map for memory allocation.  Do not instantiate this directly; use
-// the NewHashMapOptions function instead.
-type HashMapOptions struct {
+// the NewHashmapOptions function instead.
+type HashmapOptions struct {
 	BucketStrategy memory.BlockSize
-	KeyConfig      HandlerConfig
-	ValueConfig    HandlerConfig
 }
 
-func DefaultHashMapOptions() *HashMapOptions {
-	return &HashMapOptions{
+func DefaultHashmapOptions() *HashmapOptions {
+	return &HashmapOptions{
 		BucketStrategy: memory.LargeBlock,
 	}
 }

--- a/core/hashmap_options_test.go
+++ b/core/hashmap_options_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/object88/immutable/memory"
 )
 
-func Test_HashMapOptions_Defaults(t *testing.T) {
-	options := core.DefaultHashMapOptions()
+func Test_HashmapOptions_Defaults(t *testing.T) {
+	options := core.DefaultHashmapOptions()
 	if options == nil {
 		t.Fatalf("Default method returned nil\n")
 	}
@@ -17,8 +17,8 @@ func Test_HashMapOptions_Defaults(t *testing.T) {
 	}
 }
 
-func Test_HashMapOptions_WithBucketStrategy(t *testing.T) {
-	options := core.DefaultHashMapOptions()
+func Test_HashmapOptions_WithBucketStrategy(t *testing.T) {
+	options := core.DefaultHashmapOptions()
 	f := core.WithBucketStrategy(memory.ExtraLargeBlock)
 	if nil == f {
 		t.Fatalf("Fn returned from WithBucketStrategy is nil\n")
@@ -30,7 +30,7 @@ func Test_HashMapOptions_WithBucketStrategy(t *testing.T) {
 }
 
 func Test_HashmapOptions_CreateHashmapWithOptions(t *testing.T) {
-	options := core.DefaultHashMapOptions()
+	options := core.DefaultHashmapOptions()
 	fn := core.WithBucketStrategy(memory.ExtraLargeBlock)
 	fn(options)
 	if options.BucketStrategy != memory.ExtraLargeBlock {

--- a/core/types.go
+++ b/core/types.go
@@ -4,6 +4,7 @@ import "unsafe"
 
 type HashmapConfig struct {
 	KeyConfig   HandlerConfig
+	Options     *HashmapOptions
 	ValueConfig HandlerConfig
 }
 

--- a/core/types.go
+++ b/core/types.go
@@ -2,6 +2,11 @@ package core
 
 import "unsafe"
 
+type HashmapConfig struct {
+	KeyConfig   HandlerConfig
+	ValueConfig HandlerConfig
+}
+
 type HandlerConfig interface {
 	Compare(a, b unsafe.Pointer) (match bool)
 	CompareTo(memory unsafe.Pointer, index int, other unsafe.Pointer) (match bool)

--- a/handlers/booleans/boolHandling.go
+++ b/handlers/booleans/boolHandling.go
@@ -26,11 +26,11 @@ package booleans
 //
 // // WithBoolKeyMetadata establishes the hydrator and dehydrator methods
 // // for working with integer keys.
-// func WithBoolKeyMetadata(o *core.HashMapOptions) {
+// func WithBoolKeyMetadata(o *core.HashmapOptions) {
 // 	o.KeyConfig = createOneBoolHandler()
 // }
 //
-// func WithBoolValueMetadata(o *core.HashMapOptions) {
+// func WithBoolValueMetadata(o *core.HashmapOptions) {
 // 	o.ValueConfig = createOneBoolHandler()
 // }
 //

--- a/handlers/integers/intHandling.go
+++ b/handlers/integers/intHandling.go
@@ -19,18 +19,6 @@ func GetHandler() core.HandlerConfig {
 	return config
 }
 
-// WithIntKeyMetadata establishes the hydrator and dehydrator methods
-// for working with integer keys.
-func WithIntKeyMetadata(o *core.HashMapOptions) {
-	var ihc IntHandlerConfig
-	o.KeyConfig = ihc
-}
-
-func WithIntValueMetadata(o *core.HashMapOptions) {
-	var ihc IntHandlerConfig
-	o.ValueConfig = ihc
-}
-
 type IntHandlerConfig struct{}
 
 func (IntHandlerConfig) Compare(a, b unsafe.Pointer) (match bool) {

--- a/handlers/integers/intHandling.go
+++ b/handlers/integers/intHandling.go
@@ -9,8 +9,15 @@ import (
 	"github.com/object88/immutable/hasher"
 )
 
-var config *core.HandlerConfig
+var config core.HandlerConfig
 var once sync.Once
+
+func GetHandler() core.HandlerConfig {
+	once.Do(func() {
+		config = &IntHandlerConfig{}
+	})
+	return config
+}
 
 // WithIntKeyMetadata establishes the hydrator and dehydrator methods
 // for working with integer keys.

--- a/handlers/strings/stringHandling.go
+++ b/handlers/strings/stringHandling.go
@@ -8,8 +8,15 @@ import (
 	"github.com/object88/immutable/hasher"
 )
 
-var config *core.HandlerConfig
+var config core.HandlerConfig
 var once sync.Once
+
+func GetHandler() core.HandlerConfig {
+	once.Do(func() {
+		config = &StringHandlerConfig{}
+	})
+	return config
+}
 
 // WithStringKeyMetadata establishes the hydrator and dehydrator methods
 // for working with integer keys.

--- a/handlers/strings/stringHandling.go
+++ b/handlers/strings/stringHandling.go
@@ -18,18 +18,6 @@ func GetHandler() core.HandlerConfig {
 	return config
 }
 
-// WithStringKeyMetadata establishes the hydrator and dehydrator methods
-// for working with integer keys.
-func WithStringKeyMetadata(o *core.HashMapOptions) {
-	var hc StringHandlerConfig
-	o.KeyConfig = hc
-}
-
-func WithStringValueMetadata(o *core.HashMapOptions) {
-	var hc StringHandlerConfig
-	o.ValueConfig = hc
-}
-
 type StringHandlerConfig struct{}
 
 func (StringHandlerConfig) Compare(a, b unsafe.Pointer) (match bool) {

--- a/handlers/strings/stringPointerHandler.go
+++ b/handlers/strings/stringPointerHandler.go
@@ -11,11 +11,11 @@ package strings
 //
 // // WithStringPointerKeyMetadata establishes the hydrator and dehydrator methods
 // // for working with integer keys.
-// func WithStringPointerKeyMetadata(o *core.HashMapOptions) {
+// func WithStringPointerKeyMetadata(o *core.HashmapOptions) {
 // 	o.KeyConfig = createOneStringPointerHandler()
 // }
 //
-// func WithStringPointerValueMetadata(o *core.HashMapOptions) {
+// func WithStringPointerValueMetadata(o *core.HashmapOptions) {
 // 	o.ValueConfig = createOneStringPointerHandler()
 // }
 //

--- a/hashmap.go
+++ b/hashmap.go
@@ -272,7 +272,6 @@ func (h *HashMap) internalSet(config *core.HashmapConfig, key unsafe.Pointer, va
 	selectedBucket := hashkey & uint64(h.lobMask)
 	b := h.buckets[selectedBucket]
 	if b == nil {
-		// Create the bucket.
 		b = createEmptyBucket(config, hobSize)
 		h.buckets[selectedBucket] = b
 	}

--- a/hashmap.go
+++ b/hashmap.go
@@ -291,7 +291,7 @@ func (h *HashMap) internalSet(config *core.HashmapConfig, key unsafe.Pointer, va
 func createEmptyBucket(config *core.HashmapConfig, hobSize uint32) *bucket {
 	return &bucket{
 		entryCount: 0,
-		hobs:       memory.AllocateMemories(memory.LargeBlock, hobSize, bucketCapacity),
+		hobs:       memory.AllocateMemories(config.Options.BucketStrategy, hobSize, bucketCapacity),
 		keys:       config.KeyConfig.CreateBucket(bucketCapacity),
 		values:     config.ValueConfig.CreateBucket(bucketCapacity),
 		overflow:   nil,

--- a/hashmap_customkey_badhash_test.go
+++ b/hashmap_customkey_badhash_test.go
@@ -96,6 +96,7 @@ func createHashmapAndData() (*HashMap, *core.HashmapConfig, map[int]string) {
 
 	c := &core.HashmapConfig{
 		KeyConfig:   MyBadHandler{},
+		Options:     core.DefaultHashmapOptions(),
 		ValueConfig: strings.GetHandler(),
 	}
 

--- a/hashmap_customkey_badhash_test.go
+++ b/hashmap_customkey_badhash_test.go
@@ -53,12 +53,6 @@ func (MyBadHandler) Write(memory unsafe.Pointer, index int, value unsafe.Pointer
 	m[index] = *(*int)(value)
 }
 
-func WithMyBadHandlerMetadata(o *core.HashMapOptions) {
-	var handler MyBadHandler
-	o.KeyConfig = handler
-	strings.WithStringValueMetadata(o)
-}
-
 func Test_Hashmap_CustomKey_BadHash_Iterate(t *testing.T) {
 	original, config, data := createHashmapAndData()
 
@@ -99,9 +93,6 @@ func createHashmapAndData() (*HashMap, *core.HashmapConfig, map[int]string) {
 	for i := 0; i < max; i++ {
 		data[i] = strconv.Itoa(i)
 	}
-
-	opts := core.DefaultHashMapOptions()
-	WithMyBadHandlerMetadata(opts)
 
 	c := &core.HashmapConfig{
 		KeyConfig:   MyBadHandler{},

--- a/hashmap_gostringer.go
+++ b/hashmap_gostringer.go
@@ -3,11 +3,13 @@ package immutable
 import (
 	"bytes"
 	"fmt"
+
+	"github.com/object88/immutable/core"
 )
 
 // GoString provides a programmatic view into a HashMap.  This may be used,
 // for example, with the '%#v' operand to fmt.Printf, fmt.Sprintf, etc.
-func (h *HashMap) GoString() string {
+func (h *HashMap) GoString(config *core.HashmapConfig) string {
 	var buffer bytes.Buffer
 	buffer.WriteString(fmt.Sprintf("Size: %d\n[\n", h.size))
 	for k, v := range h.buckets {
@@ -19,13 +21,11 @@ func (h *HashMap) GoString() string {
 		buffer.WriteString(fmt.Sprintf("  bucket #%d: {\n    entryCount: %d\n    entries: [\n", k, b.entryCount))
 		for b != nil {
 			for i := 0; i < int(b.entryCount); i++ {
-				key := h.options.KeyConfig.Read(b.keys, i)
-				value := h.options.ValueConfig.Read(b.values, i)
+				key := config.KeyConfig.Read(b.keys, i)
+				value := config.ValueConfig.Read(b.values, i)
 
-				ks := h.options.KeyConfig.Format(key)
-				vs := h.options.ValueConfig.Format(value)
-				// k, _ := b.keys.Hydrate(i).(core.Element)
-				// v := b.values.Hydrate(i)
+				ks := config.KeyConfig.Format(key)
+				vs := config.ValueConfig.Format(value)
 				buffer.WriteString(fmt.Sprintf("      [0x%016x,%s] -> %s\n", b.hobs.Read(uint64(i)), ks, vs))
 			}
 

--- a/hashmap_stringer.go
+++ b/hashmap_stringer.go
@@ -4,16 +4,18 @@ import (
 	"bytes"
 	"fmt"
 	"unsafe"
+
+	"github.com/object88/immutable/core"
 )
 
-func (h *HashMap) String() string {
+func (h *HashMap) String(config *core.HashmapConfig) string {
 	var buffer bytes.Buffer
 	buffer.WriteString("Size: ")
 	buffer.WriteString(fmt.Sprintf("%d", h.size))
 	buffer.WriteString("\n[\n")
-	h.ForEach(func(k unsafe.Pointer, v unsafe.Pointer) {
-		ks := h.options.KeyConfig.Format(k)
-		vs := h.options.ValueConfig.Format(v)
+	h.ForEach(config, func(k unsafe.Pointer, v unsafe.Pointer) {
+		ks := config.KeyConfig.Format(k)
+		vs := config.ValueConfig.Format(v)
 		buffer.WriteString(fmt.Sprintf("  %s: %s\n", ks, vs))
 	})
 	buffer.WriteString("]\n")

--- a/intToStringHashmap.go
+++ b/intToStringHashmap.go
@@ -16,8 +16,6 @@ type IntToStringHashmap struct {
 
 func NewIntToStringHashmap(contents map[int]string, options ...core.HashMapOption) *IntToStringHashmap {
 	opts := core.DefaultHashMapOptions()
-	integers.WithIntKeyMetadata(opts)
-	strings.WithStringValueMetadata(opts)
 	for _, fn := range options {
 		fn(opts)
 	}

--- a/intToStringHashmap.go
+++ b/intToStringHashmap.go
@@ -14,14 +14,15 @@ type IntToStringHashmap struct {
 	c *core.HashmapConfig
 }
 
-func NewIntToStringHashmap(contents map[int]string, options ...core.HashMapOption) *IntToStringHashmap {
-	opts := core.DefaultHashMapOptions()
+func NewIntToStringHashmap(contents map[int]string, options ...core.HashmapOption) *IntToStringHashmap {
+	opts := core.DefaultHashmapOptions()
 	for _, fn := range options {
 		fn(opts)
 	}
 
 	c := &core.HashmapConfig{
 		KeyConfig:   integers.GetHandler(),
+		Options:     opts,
 		ValueConfig: strings.GetHandler(),
 	}
 

--- a/intToStringHashmap.go
+++ b/intToStringHashmap.go
@@ -11,6 +11,7 @@ import (
 
 type IntToStringHashmap struct {
 	h *HashMap
+	c *core.HashmapConfig
 }
 
 func NewIntToStringHashmap(contents map[int]string, options ...core.HashMapOption) *IntToStringHashmap {
@@ -21,13 +22,18 @@ func NewIntToStringHashmap(contents map[int]string, options ...core.HashMapOptio
 		fn(opts)
 	}
 
-	hash := CreateEmptyHashmap(len(contents), opts)
+	c := &core.HashmapConfig{
+		KeyConfig:   integers.GetHandler(),
+		ValueConfig: strings.GetHandler(),
+	}
+
+	hash := CreateEmptyHashmap(len(contents))
 
 	for k, v := range contents {
 		key, value := k, v
-		hash.internalSet(unsafe.Pointer(&key), unsafe.Pointer(&value))
+		hash.internalSet(c, unsafe.Pointer(&key), unsafe.Pointer(&value))
 	}
-	return &IntToStringHashmap{hash}
+	return &IntToStringHashmap{hash, c}
 }
 
 // Filter returns a subset of the collection, based on the predicate supplied
@@ -35,14 +41,14 @@ func (hm *IntToStringHashmap) Filter(predicate func(key int, value string) (bool
 	if hm == nil {
 		return nil, errors.New("Pointer receiver is nil")
 	}
-	newHashmap, err := hm.h.Filter(func(kp unsafe.Pointer, vp unsafe.Pointer) (bool, error) {
+	newHashmap, err := hm.h.Filter(hm.c, func(kp unsafe.Pointer, vp unsafe.Pointer) (bool, error) {
 		key, value := *(*int)(kp), *(*string)(vp)
 		return predicate(key, value)
 	})
 	if err != nil {
 		return nil, err
 	}
-	return &IntToStringHashmap{newHashmap}, nil
+	return &IntToStringHashmap{newHashmap, hm.c}, nil
 }
 
 // ForEach iterates over each key-value pair in this collection
@@ -50,7 +56,7 @@ func (hm *IntToStringHashmap) ForEach(predicate func(key int, value string)) {
 	if hm == nil {
 		return
 	}
-	hm.h.ForEach(func(kp unsafe.Pointer, vp unsafe.Pointer) {
+	hm.h.ForEach(hm.c, func(kp unsafe.Pointer, vp unsafe.Pointer) {
 		key, value := *(*int)(kp), *(*string)(vp)
 		predicate(key, value)
 	})
@@ -61,7 +67,7 @@ func (hm *IntToStringHashmap) Get(key int) (value string, ok bool, err error) {
 		return "", false, errors.New("Pointer receiver is nil")
 	}
 	k := unsafe.Pointer(&key)
-	r, ok, err := hm.h.Get(k)
+	r, ok, err := hm.h.Get(hm.c, k)
 	if err != nil {
 		return "", false, err
 	}
@@ -77,7 +83,7 @@ func (hm *IntToStringHashmap) GetKeys() (results []int, err error) {
 		return nil, errors.New("Pointer receiver is nil")
 	}
 	var a []unsafe.Pointer
-	a, err = hm.h.GetKeys()
+	a, err = hm.h.GetKeys(hm.c)
 	if err != nil {
 		return nil, err
 	}
@@ -92,7 +98,7 @@ func (hm *IntToStringHashmap) GoString() string {
 	if hm == nil {
 		return "(nil)"
 	}
-	return hm.h.GoString()
+	return hm.h.GoString(hm.c)
 }
 
 func (hm *IntToStringHashmap) Insert(key int, value string) (result *IntToStringHashmap, err error) {
@@ -100,21 +106,21 @@ func (hm *IntToStringHashmap) Insert(key int, value string) (result *IntToString
 		return nil, errors.New("Pointer receiver is nil")
 	}
 	kp, vp := unsafe.Pointer(&key), unsafe.Pointer(&value)
-	newHashmap, err := hm.h.Insert(kp, vp)
+	newHashmap, err := hm.h.Insert(hm.c, kp, vp)
 	if err != nil {
 		return nil, err
 	}
 	if newHashmap == hm.h {
 		return hm, nil
 	}
-	return &IntToStringHashmap{newHashmap}, nil
+	return &IntToStringHashmap{newHashmap, hm.c}, nil
 }
 
 func (hm *IntToStringHashmap) Map(predicate func(key int, value string) (result string, err error)) (*IntToStringHashmap, error) {
 	if hm == nil {
 		return nil, errors.New("Pointer receiver is nil")
 	}
-	newHashmap, err := hm.h.Map(func(kp, vp unsafe.Pointer) (newv unsafe.Pointer, err error) {
+	newHashmap, err := hm.h.Map(hm.c, func(kp, vp unsafe.Pointer) (newv unsafe.Pointer, err error) {
 		key, value := *(*int)(kp), *(*string)(vp)
 		newS, err := predicate(key, value)
 		if err != nil {
@@ -125,7 +131,7 @@ func (hm *IntToStringHashmap) Map(predicate func(key int, value string) (result 
 	if err != nil {
 		return nil, err
 	}
-	return &IntToStringHashmap{newHashmap}, nil
+	return &IntToStringHashmap{newHashmap, hm.c}, nil
 }
 
 func (hm *IntToStringHashmap) Reduce(accumulator interface{}, predicate func(accumulator interface{}, key int, value string) (interface{}, error)) (result interface{}, err error) {
@@ -133,7 +139,7 @@ func (hm *IntToStringHashmap) Reduce(accumulator interface{}, predicate func(acc
 		return nil, errors.New("Pointer receiver is nil")
 	}
 	acc := accumulator
-	_, err = hm.h.Reduce(func(ap unsafe.Pointer, kp, vp unsafe.Pointer) (unsafe.Pointer, error) {
+	_, err = hm.h.Reduce(hm.c, func(ap unsafe.Pointer, kp, vp unsafe.Pointer) (unsafe.Pointer, error) {
 		key, value := *(*int)(kp), *(*string)(vp)
 		acc, err = predicate(acc, key, value)
 		return nil, err
@@ -152,14 +158,14 @@ func (hm *IntToStringHashmap) Remove(key int) (*IntToStringHashmap, error) {
 	}
 
 	kp := unsafe.Pointer(&key)
-	newHashmap, err := hm.h.Remove(kp)
+	newHashmap, err := hm.h.Remove(hm.c, kp)
 	if err != nil {
 		return nil, err
 	}
 	if newHashmap == hm.h {
 		return hm, nil
 	}
-	return &IntToStringHashmap{newHashmap}, nil
+	return &IntToStringHashmap{newHashmap, hm.c}, nil
 }
 
 func (hm *IntToStringHashmap) Size() int {
@@ -173,5 +179,5 @@ func (hm *IntToStringHashmap) String() string {
 	if hm == nil {
 		return "(nil)"
 	}
-	return hm.h.String()
+	return hm.h.String(hm.c)
 }

--- a/intToStringHashmap.go
+++ b/intToStringHashmap.go
@@ -13,15 +13,15 @@ type IntToStringHashmap struct {
 	h *HashMap
 }
 
-func NewIntToStringHashmap(contents map[int]string) *IntToStringHashmap {
+func NewIntToStringHashmap(contents map[int]string, options ...core.HashMapOption) *IntToStringHashmap {
 	opts := core.DefaultHashMapOptions()
 	integers.WithIntKeyMetadata(opts)
 	strings.WithStringValueMetadata(opts)
-	// for _, fn := range options {
-	// 	fn(opts)
-	// }
+	for _, fn := range options {
+		fn(opts)
+	}
 
-	hash := createHashMap(len(contents), opts)
+	hash := CreateEmptyHashmap(len(contents), opts)
 
 	for k, v := range contents {
 		key, value := k, v

--- a/stringToStringHashmap.go
+++ b/stringToStringHashmap.go
@@ -20,7 +20,7 @@ func NewStringToStringHashmap(contents map[string]string) *StringToStringHashmap
 	// 	fn(opts)
 	// }
 
-	hash := createHashMap(len(contents), opts)
+	hash := CreateEmptyHashmap(len(contents), opts)
 
 	for k, v := range contents {
 		key, value := k, v

--- a/stringToStringHashmap.go
+++ b/stringToStringHashmap.go
@@ -13,7 +13,7 @@ package immutable
 // }
 //
 // func NewStringToStringHashmap(contents map[string]string) *StringToStringHashmap {
-// 	opts := core.DefaultHashMapOptions()
+// 	opts := core.DefaultHashmapOptions()
 // 	strings.WithStringKeyMetadata(opts)
 // 	strings.WithStringValueMetadata(opts)
 // 	// for _, fn := range options {

--- a/stringToStringHashmap.go
+++ b/stringToStringHashmap.go
@@ -1,56 +1,56 @@
 package immutable
 
-import (
-	"fmt"
-	"unsafe"
-
-	"github.com/object88/immutable/core"
-	"github.com/object88/immutable/handlers/strings"
-)
-
-type StringToStringHashmap struct {
-	h *HashMap
-}
-
-func NewStringToStringHashmap(contents map[string]string) *StringToStringHashmap {
-	opts := core.DefaultHashMapOptions()
-	strings.WithStringKeyMetadata(opts)
-	strings.WithStringValueMetadata(opts)
-	// for _, fn := range options {
-	// 	fn(opts)
-	// }
-
-	hash := CreateEmptyHashmap(len(contents), opts)
-
-	for k, v := range contents {
-		key, value := k, v
-		hash.internalSet(unsafe.Pointer(&key), unsafe.Pointer(&value))
-	}
-	return &StringToStringHashmap{hash}
-}
-
-func (stsh *StringToStringHashmap) Get(key string) string {
-	k := unsafe.Pointer(&key)
-	r, ok, err := stsh.h.Get(k)
-	if err != nil {
-		panic("NOPE")
-	}
-	if !ok {
-		fmt.Printf("!ok\n")
-	}
-	fmt.Printf("value: %#v\n", r)
-	v := *(*string)(r)
-	return v
-}
-
-func (stsh *StringToStringHashmap) Insert(key string, value string) {
-
-}
-
-func (stsh *StringToStringHashmap) Size() int {
-	return stsh.h.Size()
-}
-
-func (stsh *StringToStringHashmap) String() string {
-	return stsh.h.String()
-}
+// import (
+// 	"fmt"
+// 	"unsafe"
+//
+// 	"github.com/object88/immutable/core"
+// 	"github.com/object88/immutable/handlers/strings"
+// )
+//
+// type StringToStringHashmap struct {
+// 	h *HashMap
+// }
+//
+// func NewStringToStringHashmap(contents map[string]string) *StringToStringHashmap {
+// 	opts := core.DefaultHashMapOptions()
+// 	strings.WithStringKeyMetadata(opts)
+// 	strings.WithStringValueMetadata(opts)
+// 	// for _, fn := range options {
+// 	// 	fn(opts)
+// 	// }
+//
+// 	hash := CreateEmptyHashmap(len(contents), opts)
+//
+// 	for k, v := range contents {
+// 		key, value := k, v
+// 		hash.internalSet(unsafe.Pointer(&key), unsafe.Pointer(&value))
+// 	}
+// 	return &StringToStringHashmap{hash}
+// }
+//
+// func (stsh *StringToStringHashmap) Get(key string) string {
+// 	k := unsafe.Pointer(&key)
+// 	r, ok, err := stsh.h.Get(k)
+// 	if err != nil {
+// 		panic("NOPE")
+// 	}
+// 	if !ok {
+// 		fmt.Printf("!ok\n")
+// 	}
+// 	fmt.Printf("value: %#v\n", r)
+// 	v := *(*string)(r)
+// 	return v
+// }
+//
+// func (stsh *StringToStringHashmap) Insert(key string, value string) {
+//
+// }
+//
+// func (stsh *StringToStringHashmap) Size() int {
+// 	return stsh.h.Size()
+// }
+//
+// func (stsh *StringToStringHashmap) String() string {
+// 	return stsh.h.String()
+// }


### PR DESCRIPTION
See #60 

When creating a empty Hashmap, return a common instance to reduce memory usage.